### PR TITLE
BOOTy can now build a real initrd

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,86 @@
 package main
 
-import "github.com/thebsdbox/BOOTy/cmd"
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/thebsdbox/BOOTy/pkg/realm"
+)
 
 func main() {
 
-	cmd.Execute()
+	// Fuck it
 
+	//cmd.Execute()
+	m := realm.DefaultMounts()
+	d := realm.DefaultDevices()
+	dev := m.GetMount("dev")
+	dev.CreateMount = true
+	dev.EnableMount = true
+
+	proc := m.GetMount("proc")
+	proc.CreateMount = true
+	proc.EnableMount = true
+
+	tmp := m.GetMount("tmp")
+	tmp.CreateMount = true
+	tmp.EnableMount = true
+
+	// Create all folders
+	m.CreateFolder()
+	// Ensure that /dev is mounted (first)
+	m.CreateNamedMount("dev", true)
+
+	// Create all devices
+	d.CreateDevice()
+
+	// Mount any additional mounts
+	m.CreateMount()
+
+	log.Println("Starting DHCP client")
+	go realm.DHCPClient()
+
+	// HERE IS WHERE THE MAIN CODE GOES
+
+	// Shell stuff
+	log.Println("Starting Shell")
+	cmd := exec.Command("/bin/sh")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	err := cmd.Start()
+	if err != nil {
+		log.Errorf("Shell error [%v]", err)
+	}
+	log.Printf("Waiting for command to finish...")
+	err = cmd.Wait()
+	if err != nil {
+		log.Errorf("Shell error [%v]", err)
+	}
+	log.Infoln()
+	exit()
+}
+
+func exit() {
+	var err error
+
+	err = syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART)
+	if err != nil {
+		log.Printf("reboot off failed: %v", err)
+	}
+
+	// err = syscall.Reboot(syscall.LINUX_REBOOT_CMD_POWER_OFF)
+	// if err != nil {
+	// 	log.Printf("power off failed: %v", err)
+	// }
+
+	// err = syscall.Reboot(syscall.LINUX_REBOOT_CMD_HALT)
+	// if err != nil {
+	// 	log.Printf("halt failed: %v", err)
+	// }
+
+	os.Exit(1)
+	select {}
 }

--- a/pkg/realm/device.go
+++ b/pkg/realm/device.go
@@ -1,0 +1,79 @@
+package realm
+
+import (
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// DefaultDevices will return the defult mounts
+func DefaultDevices() *Devices {
+	d := &Devices{}
+
+	// null device
+	null := Device{
+		CreateDevice: false,
+
+		Name:  "null",
+		Path:  "/dev/null",
+		Mode:  syscall.S_IFCHR,
+		Major: 1,
+		Minor: 3,
+	}
+	d.Device = append(d.Device, null)
+
+	// random device
+	random := Device{
+		CreateDevice: false,
+
+		Name:  "random",
+		Path:  "/dev/random",
+		Mode:  syscall.S_IFCHR,
+		Major: 1,
+		Minor: 8,
+	}
+	d.Device = append(d.Device, random)
+
+	// null device
+	urandom := Device{
+		CreateDevice: false,
+
+		Name:  "urandom",
+		Path:  "/dev/urandom",
+		Mode:  syscall.S_IFCHR,
+		Major: 1,
+		Minor: 9,
+	}
+	d.Device = append(d.Device, urandom)
+
+	return d
+}
+
+// CreateDevice -
+func (d *Devices) CreateDevice() error {
+
+	for x := range d.Device {
+		if d.Device[x].CreateDevice == true {
+			err := syscall.Mknod(d.Device[x].Path, d.Device[x].Mode, makedev(d.Device[x].Major, d.Device[x].Minor))
+			if err != nil {
+				log.Errorf("Device Error [%v]", err)
+			}
+		}
+	}
+	return nil
+}
+
+// GetDevice -
+func (d *Devices) GetDevice(name string) *Device {
+
+	for x := range d.Device {
+		if d.Device[x].Name == name {
+			return &d.Device[x]
+		}
+	}
+	return nil
+}
+
+func makedev(major, minor int64) int {
+	return int(((major & 0xfff) << 8) | (minor & 0xff) | ((major &^ 0xfff) << 32) | ((minor & 0xfffff00) << 12))
+}

--- a/pkg/realm/mount.go
+++ b/pkg/realm/mount.go
@@ -1,0 +1,170 @@
+package realm
+
+import (
+	"os"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// DefaultMounts will return the defult mounts
+func DefaultMounts() *Mounts {
+	m := &Mounts{}
+
+	// bin Mount
+	bin := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "bin",
+		Path:        "/bin",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, bin)
+
+	//
+	dev := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "dev",
+		Source:      "devtmpfs",
+		Path:        "/dev",
+		FSType:      "devtmpfs",
+		Flags:       syscall.MS_MGC_VAL,
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, dev)
+
+	//
+	etc := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "etc",
+		Path:        "/etc",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, etc)
+
+	//
+	home := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "home",
+		Path:        "/home",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, home)
+
+	//
+	mnt := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "mnt",
+		Path:        "/mnt",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, mnt)
+
+	//
+	proc := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "proc",
+		Source:      "proc",
+		Path:        "/proc",
+		FSType:      "proc",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, proc)
+
+	//
+	sys := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "sys",
+		Path:        "/sys",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, sys)
+
+	//
+	tmp := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "tmp",
+		Source:      "tmpfs",
+		Path:        "/tmp",
+		FSType:      "tmpfs",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, tmp)
+
+	//
+	usr := Mount{
+		CreateMount: false,
+		EnableMount: false,
+		Name:        "usr",
+		Path:        "/usr",
+		Mode:        0777,
+	}
+	m.Mount = append(m.Mount, usr)
+
+	return m
+}
+
+// CreateFolder -
+func (m *Mounts) CreateFolder() error {
+
+	for x := range m.Mount {
+		if m.Mount[x].CreateMount == true {
+			err := os.MkdirAll(m.Mount[x].Path, m.Mount[x].Mode)
+			if err != nil {
+				log.Errorf("Folder[%s] create error [%v]", m.Mount[x].Path, err)
+			}
+		}
+	}
+	return nil
+}
+
+// CreateMount -
+func (m *Mounts) CreateMount() error {
+	for x := range m.Mount {
+		if m.Mount[x].CreateMount == true {
+			err := syscall.Mount(m.Mount[x].Name, m.Mount[x].Path, m.Mount[x].FSType, m.Mount[x].Flags, m.Mount[x].Options)
+			if err != nil {
+				log.Errorf("Mount [%s] create error [%v]", m.Mount[x].Name, err)
+			}
+			log.Infof("Mounted [%s] -> [%s]", m.Mount[x].Name, m.Mount[x].Path)
+		}
+	}
+	return nil
+}
+
+// CreateNamedMount -
+func (m *Mounts) CreateNamedMount(name string, remove bool) error {
+	for x := range m.Mount {
+		if m.Mount[x].Name == name && m.Mount[x].CreateMount == true {
+			err := syscall.Mount(m.Mount[x].Name, m.Mount[x].Path, m.Mount[x].FSType, m.Mount[x].Flags, m.Mount[x].Options)
+			if err != nil {
+				log.Errorf("Mount [%s] create error [%v]", m.Mount[x].Name, err)
+			}
+			// Remove this element
+			if remove {
+				m.Mount = append(m.Mount[:x], m.Mount[x+1:]...)
+			}
+			log.Infof("Mounted [%s] -> [%s]", m.Mount[x].Name, m.Mount[x].Path)
+			return nil
+		}
+	}
+	return nil
+}
+
+// GetMount -
+func (m *Mounts) GetMount(name string) *Mount {
+
+	for x := range m.Mount {
+		if m.Mount[x].Name == name {
+			return &m.Mount[x]
+		}
+	}
+	return nil
+}

--- a/pkg/realm/networking.go
+++ b/pkg/realm/networking.go
@@ -1,0 +1,120 @@
+package realm
+
+import (
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+
+	"github.com/digineo/go-dhclient"
+	"github.com/google/gopacket/layers"
+)
+
+const ifname = "eth0"
+
+var (
+//options = optionList{}
+//requestParams = byteList{}
+)
+
+// DHCPClient starts the DHCP client listening for a lease
+func DHCPClient() error {
+
+	// Bring up interface
+	ifaceDev, err := netlink.LinkByName(ifname)
+	if err != nil {
+		log.Errorf("Error finding adapter [%v]", err)
+
+		return err
+	}
+
+	if err := netlink.LinkSetUp(ifaceDev); err != nil {
+		log.Errorf("Error bringing up adapter [%v]", err)
+	}
+
+	// Setup interface to recieve DHCP traffic
+	iface, err := net.InterfaceByName(ifname)
+	if err != nil {
+		log.Errorf("Error finding interface by name [%v]", err)
+
+		return err
+	}
+	client := dhclient.Client{
+		Iface: iface,
+		OnBound: func(lease *dhclient.Lease) {
+			link, _ := netlink.LinkByName(iface.Name)
+
+			cidr := net.IPNet{
+				IP:   lease.FixedAddress,
+				Mask: lease.Netmask,
+			}
+			addr, _ := netlink.ParseAddr(cidr.String())
+
+			err = netlink.AddrAdd(link, addr)
+			if err != nil {
+				log.Errorf("Error adding %s to link %s", cidr.String(), iface.Name)
+			} else {
+				log.Printf("Adding %s to link %s", cidr.String(), iface.Name)
+			}
+
+			route := netlink.Route{
+				Scope: netlink.SCOPE_UNIVERSE,
+				Gw:    lease.ServerID,
+			}
+			if err := netlink.RouteAdd(&route); err != nil {
+				log.Errorf("Error setting gateway [%v]", err)
+			} else {
+				log.Printf("Adding gateway %s to link %s", lease.ServerID.String(), iface.Name)
+			}
+		},
+	}
+
+	// Add requests for default options
+	for _, param := range dhclient.DefaultParamsRequestList {
+		log.Printf("Requesting default option %d", param)
+		client.AddParamRequest(layers.DHCPOpt(param))
+	}
+
+	// // Add requests for custom options
+	// for _, param := range requestParams {
+	// 	log.Printf("Requesting custom option %d", param)
+	// 	client.AddParamRequest(layers.DHCPOpt(param))
+	// }
+
+	// Add hostname option
+	hostname, _ := os.Hostname()
+	client.AddOption(layers.DHCPOptHostname, []byte(hostname))
+
+	// // Add custom options
+	// for _, option := range options {
+	// 	log.Printf("Adding option %d=0x%x", option.Type, option.Data)
+	// 	client.AddOption(option.Type, option.Data)
+	// }
+
+	client.Start()
+	defer client.Stop()
+
+	// Below will sit
+
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGUSR1)
+	for {
+		sig := <-c
+		log.Println("received", sig)
+		switch sig {
+		case syscall.SIGINT, syscall.SIGTERM:
+			return nil
+		case syscall.SIGHUP:
+			log.Println("renew lease")
+			client.Renew()
+		case syscall.SIGUSR1:
+			log.Println("acquire new lease")
+			client.Rebind()
+		}
+	}
+	log.Errorf("DHCP client has ended")
+	return nil
+}

--- a/pkg/realm/types.go
+++ b/pkg/realm/types.go
@@ -1,0 +1,43 @@
+package realm
+
+import "os"
+
+// Mount contains the configuration for a single mount within the initramfs
+type Mount struct {
+	// Create the location on disk
+	CreateMount bool
+	// Enable the mount Source -> Path w/options
+	EnableMount bool
+
+	// Configurations
+	Name    string
+	Source  string
+	Path    string
+	Mode    os.FileMode
+	FSType  string
+	Flags   uintptr
+	Options string
+}
+
+// Mounts are the paths that can be mounted or created on boot
+type Mounts struct {
+	Mount []Mount
+}
+
+// Device contains the configuration for a single device within the initramfs
+type Device struct {
+	// Create the device within the ramdisk
+	CreateDevice bool
+
+	// Configuration for the device
+	Name  string
+	Path  string
+	Mode  uint32
+	Major int64
+	Minor int64
+}
+
+// Devices are the devices that can be created on boot
+type Devices struct {
+	Device []Device
+}


### PR DESCRIPTION
The `initrd.Dockerfile` builds everything needed for BOOTy to run within an `initramfs`.

The `pkg/realm` contains:

- `DHCP Client` will retrieve an address (hardcoded to eth0)
- `Mount` and `Folder` management
- `Device` management