### PR TITLE
Adds a ticker to the status reporting

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -10,42 +10,38 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/dustin/go-humanize"
 )
 
+var tick chan time.Time
+
+// WriteCounter counts the number of bytes written to it. It implements to the io.Writer interface
+// and we can pass this into io.TeeReader() which will report progress on each write cycle.
+type WriteCounter struct {
+	Total uint64
+}
+
+func (wc *WriteCounter) Write(p []byte) (int, error) {
+	n := len(p)
+	wc.Total += uint64(n)
+	return n, nil
+}
+
+func tickerProgress(byteCounter uint64) {
+	// Clear the line by using a character return to go back to the start and remove
+	// the remaining characters by filling it with spaces
+	fmt.Printf("\r%s", strings.Repeat(" ", 35))
+
+	// Return again and print current status of download
+	// We use the humanize package to print the bytes in a meaningful way (e.g. 10 MB)
+	fmt.Printf("\rDownloading... %s complete", humanize.Bytes(byteCounter))
+}
+
 // Read - will take a local disk and copy an image to a remote server
 func Read(sourceDevice, destinationAddress string) error {
-	// path := os.Getenv("CMDLINEPATH")
-	// if path == "" {
-	// 	path = utils.CmdlinePath
-	// }
-	// utils.ClearScreen()
-	// fmt.Println("--------------------------------------------------------------------------------")
-	// fmt.Printf("Starting BOOTy \n")
-	// fmt.Printf("\n\n")
-	// fmt.Printf("Parsing config from [%s]\n", path)
 
-	// src, dst, err := utils.ParseCmdLine(path)
-	// if err != nil {
-	// 	log.Fatalf("%v", err)
-	// }
-
-	// envSrc := os.Getenv("SRC")
-	// envDst := os.Getenv("DST")
-	// if envSrc == "" {
-	// 	//fmt.Printf("The \"SRC\" environment variable wasn't set")
-	// } else {
-	// 	src = envSrc
-	// }
-
-	// if envDst == "" {
-	// 	//fmt.Printf("The \"DST\" environment variable wasn't set")
-	// } else {
-	// 	dst = envDst
-	// }
-
-	// TODO - consider timeouts
 	fmt.Println("--------------------------------------------------------------------------------")
 
 	fmt.Printf("\nReading of disk [%s], and sending to [%s]\n", filepath.Base(sourceDevice), destinationAddress)
@@ -57,11 +53,58 @@ func Read(sourceDevice, destinationAddress string) error {
 		return err
 	}
 
-	// TODO - reboot
-	// fmt.Println("This is where the push reboot happens :-D")
-	// realm.Reboot()
+	return nil
+}
 
-	// time.Sleep(time.Second * 5)
+// Write will pull an image and write it to local storage device
+func Write(sourceImage, destinationDevice string) error {
+
+	req, err := http.NewRequest("GET", sourceImage, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var out io.Writer
+	f, err := os.OpenFile(destinationDevice, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	out = f
+	defer f.Close()
+
+	fmt.Printf("\n\n\n")
+
+	fmt.Printf("Beginning write of image [%s] to disk [%s]", filepath.Base(sourceImage), destinationDevice)
+	fmt.Printf("\n\n\n")
+	// Create our progress reporter and pass it to be used alongside our writer
+	ticker := time.NewTicker(500 * time.Millisecond)
+	counter := &WriteCounter{}
+
+	go func() {
+		for ; true; <-ticker.C {
+			tickerProgress(counter.Total)
+		}
+	}()
+	if _, err = io.Copy(out, io.TeeReader(resp.Body, counter)); err != nil {
+		return err
+	}
+
+	count, err := io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error writing %d bytes to disk [%s] -> %v", count, destinationDevice, err)
+	}
+	ticker.Stop()
+	fmt.Printf("\n\n\n")
+
+	fmt.Println("--------------------------------------------------------------------------------")
+	fmt.Printf("\n\n\n\n")
+
 	return nil
 }
 
@@ -117,104 +160,4 @@ func UploadMultipartFile(client *http.Client, uri, key, path string) (*http.Resp
 	}
 
 	return resp, nil
-}
-
-// WriteCounter counts the number of bytes written to it. It implements to the io.Writer interface
-// and we can pass this into io.TeeReader() which will report progress on each write cycle.
-type WriteCounter struct {
-	Total uint64
-}
-
-func (wc *WriteCounter) Write(p []byte) (int, error) {
-	n := len(p)
-	wc.Total += uint64(n)
-	wc.PrintProgress()
-	return n, nil
-}
-
-//PrintProgress -
-func (wc WriteCounter) PrintProgress() {
-	// Clear the line by using a character return to go back to the start and remove
-	// the remaining characters by filling it with spaces
-	fmt.Printf("\r%s", strings.Repeat(" ", 35))
-
-	// Return again and print current status of download
-	// We use the humanize package to print the bytes in a meaningful way (e.g. 10 MB)
-	fmt.Printf("\rDownloading... %s complete", humanize.Bytes(wc.Total))
-}
-
-// Write will pull an image and write it to local storage device
-func Write(sourceImage, destinationDevice string) error {
-	// path := os.Getenv("CMDLINEPATH")
-	// if path == "" {
-	// 	path = utils.CmdlinePath
-	// }
-	// utils.ClearScreen()
-	// fmt.Println("--------------------------------------------------------------------------------")
-	// fmt.Printf("Starting BOOTy \n")
-	// fmt.Printf("\n\n")
-	// fmt.Printf("Parsing config from [%s]\n", path)
-	// src, dst, err := utils.ParseCmdLine(path)
-	// if err != nil {
-	// 	log.Fatalf("%v", err)
-	// }
-
-	// envSrc := os.Getenv("SRC")
-	// envDst := os.Getenv("DST")
-	// if envSrc == "" {
-	// 	//fmt.Printf("The \"SRC\" environment variable wasn't set")
-	// } else {
-	// 	src = envSrc
-	// }
-
-	// if envDst == "" {
-	// 	//fmt.Printf("The \"DST\" environment variable wasn't set")
-	// } else {
-	// 	dst = envDst
-	// }
-
-	req, err := http.NewRequest("GET", sourceImage, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	var out io.Writer
-	f, err := os.OpenFile(destinationDevice, os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	out = f
-	defer f.Close()
-
-	fmt.Printf("\n\n\n")
-
-	fmt.Printf("Beginning write of image [%s] to disk [%s]", filepath.Base(sourceImage), destinationDevice)
-	fmt.Printf("\n\n\n")
-
-	// Create our progress reporter and pass it to be used alongside our writer
-	counter := &WriteCounter{}
-	if _, err = io.Copy(out, io.TeeReader(resp.Body, counter)); err != nil {
-		return err
-	}
-
-	count, err := io.Copy(out, resp.Body)
-	if err != nil {
-		return fmt.Errorf("Error writing %d bytes to disk [%s] -> %v", count, destinationDevice, err)
-	}
-	fmt.Printf("\n\n\n")
-
-	fmt.Println("--------------------------------------------------------------------------------")
-	fmt.Printf("\n\n\n\n")
-
-	// TODO - reboot
-	// fmt.Println("This is where the reboot happens :-D")
-	// realm.Reboot()
-	// time.Sleep(time.Second * 5)
-	return nil
 }


### PR DESCRIPTION
Using a `time.Ticker` callback we reduce the "busy" progress reporting, this was particularly a problem when watching information over a serial connection `ttyS0` the amount of interrupts and waits caused by the serial connection would reduce data rate to 50mbs. This reduces updates to 25ms, which has no noticeable affect on performance.