### PR TITLE
Enables compressed images

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ golang.org/x/net v0.0.0-20191003171128-d98b1b443823 h1:Ypyv6BNJh07T1pUSrehkLemqP
 golang.org/x/net v0.0.0-20191003171128-d98b1b443823/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f h1:QBjCr1Fz5kw158VqdE9JfI9cJnl/ymnJWAdMuinqL7Y=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/initrd.Dockerfile
+++ b/initrd.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
 
 # Build LVM2 as an init
-FROM gcc:latest as LVM
+FROM gcc:10.1.0 as LVM
 RUN wget https://mirrors.kernel.org/sourceware/lvm2/LVM2.2.03.09.tgz
 RUN tar -xf LVM2.2.03.09.tgz
 WORKDIR LVM2.2.03.09
@@ -16,7 +16,7 @@ WORKDIR tools
 RUN  gcc -O2  -fPIC  -static -L command.o dumpconfig.o formats.o lvchange.o lvconvert.o lvconvert_poll.o lvcreate.o lvdisplay.o lvextend.o lvmcmdline.o lvmdiskscan.o lvpoll.o lvreduce.o lvremove.o lvrename.o lvresize.o lvscan.o polldaemon.o pvchange.o pvck.o pvcreate.o pvdisplay.o pvmove.o pvmove_poll.o pvremove.o pvresize.o pvscan.o reporter.o segtypes.o tags.o toollib.o vgcfgbackup.o vgcfgrestore.o vgchange.o vgck.o vgcreate.o vgdisplay.o vgexport.o vgextend.o vgimport.o vgimportclone.o vgmerge.o vgmknodes.o vgreduce.o vgremove.o vgrename.o vgscan.o vgsplit.o lvm-static.o ../lib/liblvm-internal.a ../libdaemon/client/libdaemonclient.a ../device_mapper/libdevice-mapper.a ../base/libbase.a  -lm -lblkid -laio -o lvm -lpthread -luuid ./liblvm2cmd.a  
 
 # Build scripted fdisk (sfdisk)
-FROM gcc:latest as sfdisk
+FROM gcc:10.1.0 as sfdisk
 RUN apt-get update -y; apt-get install -y bison autopoint gettext
 RUN git clone https://github.com/karelzak/util-linux.git
 WORKDIR util-linux
@@ -36,7 +36,7 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
 #RUN go get; CGO_ENABLED=1 GOOS=linux go build -a -ldflags "-linkmode external -extldflags '-static' -s -w" -o init
 
 # Build Busybox
-FROM gcc:latest as Busybox
+FROM gcc:10.1.0 as Busybox
 RUN apt-get update; apt-get install -y cpio
 RUN curl -O https://busybox.net/downloads/busybox-1.31.1.tar.bz2
 RUN tar -xf busybox*bz2

--- a/main.go
+++ b/main.go
@@ -83,18 +83,24 @@ func main() {
 
 	switch cfg.Action {
 	case types.ReadImage:
-		err = image.Read(cfg.SourceDevice, cfg.DesintationAddress)
+		err = image.Read(cfg.SourceDevice, cfg.DesintationAddress, mac, cfg.Compressed)
 		if err != nil {
 			log.Errorf("Read Image Error: [%v]", err)
 			onError(cfg)
 		}
+		log.Infoln("Image written succesfully, restarting in 5 seconds")
+		time.Sleep(time.Second * 5)
+		realm.Reboot()
 
 	case types.WriteImage:
-		err = image.Write(cfg.SourceImage, cfg.DestinationDevice)
+		err = image.Write(cfg.SourceImage, cfg.DestinationDevice, cfg.Compressed)
 		if err != nil {
 			log.Errorf("Write Image Error: [%v]", err)
 			onError(cfg)
 		}
+		// log.Infoln("Image written succesfully, restarting in 5 seconds")
+		// time.Sleep(time.Second * 5)
+		// realm.Reboot()
 
 	default:
 		log.Errorf("Unknown action [%s] passed to deployment image, restarting in 10 seconds", cfg.Action)

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -3,6 +3,7 @@ package image
 // This package handles the pulling and management of images
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -41,7 +42,16 @@ func tickerProgress(byteCounter uint64) {
 }
 
 // Read - will take a local disk and copy an image to a remote server
-func Read(sourceDevice, destinationAddress string) error {
+func Read(sourceDevice, destinationAddress, mac string, compressed bool) error {
+
+	var fileName string
+	if !compressed {
+		// raw image
+		fileName = fmt.Sprintf("%s.img", mac)
+	} else {
+		// compressed image
+		fileName = fmt.Sprintf("%s.zmg", mac)
+	}
 
 	fmt.Println("--------------------------------------------------------------------------------")
 
@@ -49,7 +59,7 @@ func Read(sourceDevice, destinationAddress string) error {
 	fmt.Println("--------------------------------------------------------------------------------")
 
 	client := &http.Client{}
-	_, err := UploadMultipartFile(client, destinationAddress, "BootyImage", sourceDevice)
+	_, err := UploadMultipartFile(client, destinationAddress, fileName, sourceDevice, compressed)
 	if err != nil {
 		return err
 	}
@@ -57,8 +67,88 @@ func Read(sourceDevice, destinationAddress string) error {
 	return nil
 }
 
+//UploadMultipartFile -
+func UploadMultipartFile(client *http.Client, uri, key, path string, compressed bool) (*http.Response, error) {
+	body, writer := io.Pipe()
+
+	req, err := http.NewRequest(http.MethodPost, uri, body)
+	if err != nil {
+		return nil, err
+	}
+
+	mwriter := multipart.NewWriter(writer)
+	req.Header.Add("Content-Type", mwriter.FormDataContentType())
+
+	errchan := make(chan error)
+
+	// GO routine for the copy operation
+	go func() {
+		defer close(errchan)
+		defer writer.Close()
+		defer mwriter.Close()
+
+		// BootyImage is the key that the client will lookfor and
+		// key is the renamed file
+		w, err := mwriter.CreateFormFile("BootyImage", key)
+		if err != nil {
+			errchan <- err
+			return
+		}
+
+		diskIn, err := os.Open(path)
+		if err != nil {
+			errchan <- err
+			return
+		}
+
+		defer diskIn.Close()
+
+		if !compressed {
+			// Without compression read raw output
+			if written, err := io.Copy(w, diskIn); err != nil {
+				errchan <- fmt.Errorf("error copying %s (%d bytes written): %v", path, written, err)
+				return
+			}
+
+		} else {
+			// With compression run data through gzip writer
+			zipWriter := gzip.NewWriter(w)
+			if err != nil {
+				errchan <- fmt.Errorf("[ERROR] New gzip reader: %s", err)
+				return
+			}
+
+			// run an io.Copy on the disk into the zipWriter
+			if written, err := io.Copy(zipWriter, diskIn); err != nil {
+				errchan <- fmt.Errorf("error copying %s (%d bytes written): %v", path, written, err)
+				return
+			}
+			// Ensure we close our zipWriter (otherwise we will get "unexpected EOF")
+			err = zipWriter.Close()
+
+		}
+
+		if err := mwriter.Close(); err != nil {
+			errchan <- err
+			return
+		}
+
+	}()
+
+	resp, err := client.Do(req)
+	merr := <-errchan
+
+	if err != nil || merr != nil {
+		return resp, fmt.Errorf("http error: %v, multipart error: %v", err, merr)
+	}
+
+	return resp, nil
+}
+
 // Write will pull an image and write it to local storage device
-func Write(sourceImage, destinationDevice string) error {
+// with compress set to true it will use gzip compression to expand the data before
+// writing to an underlying device
+func Write(sourceImage, destinationDevice string, compressed bool) error {
 
 	req, err := http.NewRequest("GET", sourceImage, nil)
 	if err != nil {
@@ -79,13 +169,26 @@ func Write(sourceImage, destinationDevice string) error {
 		return fmt.Errorf("%s", resp.Status)
 	}
 
-	var out io.Writer
-	f, err := os.OpenFile(destinationDevice, os.O_CREATE|os.O_WRONLY, 0644)
+	var out io.Reader
+
+	fileOut, err := os.OpenFile(destinationDevice, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
-	out = f
-	defer f.Close()
+	defer fileOut.Close()
+
+	if !compressed {
+		// Without compression send raw output
+		out = resp.Body
+	} else {
+		// With compression run data through gzip writer
+		zipOUT, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			fmt.Println("[ERROR] New gzip reader:", err)
+		}
+		defer zipOUT.Close()
+		out = zipOUT
+	}
 
 	log.Infof("Beginning write of image [%s] to disk [%s]", filepath.Base(sourceImage), destinationDevice)
 	// Create our progress reporter and pass it to be used alongside our writer
@@ -97,70 +200,18 @@ func Write(sourceImage, destinationDevice string) error {
 			tickerProgress(counter.Total)
 		}
 	}()
-	if _, err = io.Copy(out, io.TeeReader(resp.Body, counter)); err != nil {
+	if _, err = io.Copy(fileOut, io.TeeReader(out, counter)); err != nil {
+		ticker.Stop()
 		return err
 	}
 
-	count, err := io.Copy(out, resp.Body)
+	count, err := io.Copy(fileOut, out)
 	if err != nil {
+		ticker.Stop()
 		return fmt.Errorf("Error writing %d bytes to disk [%s] -> %v", count, destinationDevice, err)
 	}
 	fmt.Printf("\n")
 
 	ticker.Stop()
 	return nil
-}
-
-//UploadMultipartFile -
-func UploadMultipartFile(client *http.Client, uri, key, path string) (*http.Response, error) {
-	body, writer := io.Pipe()
-
-	req, err := http.NewRequest(http.MethodPost, uri, body)
-	if err != nil {
-		return nil, err
-	}
-
-	mwriter := multipart.NewWriter(writer)
-	req.Header.Add("Content-Type", mwriter.FormDataContentType())
-
-	errchan := make(chan error)
-
-	go func() {
-		defer close(errchan)
-		defer writer.Close()
-		defer mwriter.Close()
-
-		w, err := mwriter.CreateFormFile(key, path)
-		if err != nil {
-			errchan <- err
-			return
-		}
-
-		in, err := os.Open(path)
-		if err != nil {
-			errchan <- err
-			return
-		}
-
-		defer in.Close()
-
-		if written, err := io.Copy(w, in); err != nil {
-			errchan <- fmt.Errorf("error copying %s (%d bytes written): %v", path, written, err)
-			return
-		}
-
-		if err := mwriter.Close(); err != nil {
-			errchan <- err
-			return
-		}
-	}()
-
-	resp, err := client.Do(req)
-	merr := <-errchan
-
-	if err != nil || merr != nil {
-		return resp, fmt.Errorf("http error: %v, multipart error: %v", err, merr)
-	}
-
-	return resp, nil
 }

--- a/pkg/plunderclient/types/types.go
+++ b/pkg/plunderclient/types/types.go
@@ -31,10 +31,12 @@ const (
 // BootyConfig defines the data passed to the BOOTy initramdisk
 type BootyConfig struct {
 	// Defines what action the deployment will take
-	Action      string `json:"action"`
-	DryRun      bool   `json:"dryRun"`
-	DropToShell bool   `json:"dropToShell"`
-	WipeDevice  bool   `json:"wipeDevice"`
+	Action string `json:"action"`
+
+	// Disk actions ->
+
+	// Data should be compressed or is compressed
+	Compressed bool `json:"compressed"`
 
 	// Write image to disk from remote address
 	SourceImage       string `json:"sourceImage,omitempty"`
@@ -57,4 +59,9 @@ type BootyConfig struct {
 	Address    string `json:"address,omitempty"`
 	Gateway    string `json:"gateway,omitempty"`
 	NameServer string `json:"nameserver,omitempty"`
+
+	// Debugging, troubleshooting
+	DryRun      bool `json:"dryRun"`
+	DropToShell bool `json:"dropToShell"`
+	WipeDevice  bool `json:"wipeDevice"`
 }


### PR DESCRIPTION
This enables compression of images through gzip, when the `compressed:` is set to true.

On both readImage and writeImage it will parse the raw data through `io.Copy()` Also fixes to the naming in the multiwriter, resulting in the created file being:

`{MAC}.img` - uncompressed
`{MAC}.zmg` - compressed